### PR TITLE
Smile Pointをfirestoreに送る

### DIFF
--- a/client/src/app/features/Chat.tsx
+++ b/client/src/app/features/Chat.tsx
@@ -103,7 +103,6 @@ const Chat: React.FC = () => {
                         <OnOffButton onClick={() => startWebSocket(socketRef, nickname, setMessages, setTotalSmilePoint, setClientsList, setStatus)} disabled={status === 1}>Connect</OnOffButton>
                         <OnOffButton onClick={() => stopWebSocket(socketRef, setMessages, setClientsList, setStatus)} disabled={status !== 1}>Disconnect</OnOffButton>
                     </div>
-                    <MessageInput onSendMessage={(message) => sendMessage(socketRef, clientId, nickname, message, setStatus)} />
                     <div>
                         <p>笑顔ポイント: {smilePoint}</p>
                     </div>
@@ -119,11 +118,6 @@ const Chat: React.FC = () => {
                     <SmileStatus smileProb={smileProb} />
                     <UserExpressions userExpressions={userExpressions} />
                     <Webcam videoRef={videoRef} />
-                    <div>
-                        {messages.map((message, index) => (
-                            <div key={index}>{message}</div>
-                        ))}
-                    </div>
                 </>
             )}
         </>

--- a/server/src/firebase/firebase.go
+++ b/server/src/firebase/firebase.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	Client       *firestore.Client
-	CollectionId = "websocket_chat"
+	CollectionId = "smilepoint_history"
 	DocId        string
 )
 
@@ -41,14 +41,14 @@ func CloseFirestore() {
 	}
 }
 
-type Message struct {
+type SmilePoint struct {
 	Timestamp time.Time `firestore:"timestamp"`
 	ClientId  string    `firestore:"client_id"`
 	Nickname  string    `firestore:"nickname"`
-	Text      string    `firestore:"text"`
+	Point     int       `firestore:"smile_point"`
 }
 
-func InsertMessage(msg Message) error {
+func SaveSmilePoint(sp SmilePoint) error {
 	ctx := context.Background()
 	if DocId == "" {
 		DocId = utils.ConvertYYYYMMDDHHMMSS(time.Now())
@@ -59,7 +59,7 @@ func InsertMessage(msg Message) error {
 	if err != nil {
 		// 存在しないなら、新しいドキュメントを作成
 		_, err = docRef.Set(ctx, map[string]interface{}{
-			"messages": []Message{msg},
+			"smile_points": []SmilePoint{sp},
 		})
 		if err != nil {
 			return err
@@ -68,8 +68,8 @@ func InsertMessage(msg Message) error {
 		// 存在するなら、既存のドキュメントにメッセージを追加
 		_, err = docRef.Update(ctx, []firestore.Update{
 			{
-				Path:  "messages",
-				Value: firestore.ArrayUnion(msg),
+				Path:  "smile_points",
+				Value: firestore.ArrayUnion(sp),
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
やったこと
- chatのmessageをdbに送っていた部分を変更し、smilepointをdbに送ってhistoryとして管理できるようにした
- server側でのchat処理自体は消さずに、client側のchatのinputタグ、送信ボタン、およびchatlogを非表示にした