### PR TITLE
[front-back/feat] 会議の状態管理の実装

### DIFF
--- a/client/src/app/features/components/ConnectionStatusButton.tsx
+++ b/client/src/app/features/components/ConnectionStatusButton.tsx
@@ -1,36 +1,53 @@
 import React from "react";
 
 interface ButtonProps {
-    status: number; // 0: 接続中, 1: 接続完了, 2: 接続終了, 3: 接続エラー
+    status: number; // 0: 接続待ち, 1: 接続完了, 2: 接続終了, 3: 接続エラー
 }
 
 const ConnectionStatusButton: React.FC<ButtonProps> = ({ status }) => {
     switch (status) {
         case 0:
             return (
-                <button disabled type="button" className="py-2.5 px-5 me-2 text-sm font-medium text-gray-900 rounded-full bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:outline-none focus:ring-blue-700 focus:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 inline-flex items-center">
-                    <svg aria-hidden="true" role="status" className="inline w-4 h-4 me-3 text-gray-200 animate-spin dark:text-gray-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
-                        <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="#1C64F2"/>
+                <button
+                    disabled
+                    type="button"
+                    className="py-2.5 px-5 me-2 text-sm font-medium text-gray-900 rounded-lg border border-blue-500 dark:bg-transparent dark:border-blue-500 dark:text-gray-400 inline-flex items-center"
+                >
+                    <svg
+                        aria-hidden="true"
+                        role="status"
+                        className="inline w-4 h-4 me-3 text-blue-500 animate-spin"
+                        viewBox="0 0 100 101"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                            fill="none" // スピナーの背景色を灰色に変更
+                        />
+                        <path
+                            d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                            fill="#a0a0ff" // スピナー本体を黄色に変更
+                        />
                     </svg>
-                    Connecting...
+                    Waiting to start ...
                 </button>
             );
         case 1:
             return (
-                <button type="button" className="text-green-700 rounded-full hover:text-white border border-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-green-500 dark:text-green-500 dark:hover:text-white dark:hover:bg-green-600 dark:focus:ring-green-800">
+                <button type="button" className="text-green-700 rounded-full border border-green-700 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-green-500 dark:text-green-500 dark:bg-transparent">
                     Connected
                 </button>
             );
         case 2:
             return(
-                <button type="button" className="text-gray-900 rounded-full hover:text-white border border-gray-800 hover:bg-gray-900 focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-gray-600 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600 dark:focus:ring-gray-800">
+                <button type="button" className="text-gray-900 rounded-full border border-gray-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-gray-600 dark:text-gray-400 dark:bg-transparent">
                     Disconnected
                 </button>
             );
         case 3:
             return (
-                <button type="button" className="text-red-700 rounded-full hover:text-white border border-red-700 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-red-500 dark:text-red-500 dark:hover:text-white dark:hover:bg-red-600 dark:focus:ring-red-900">
+                <button type="button" className="text-red-700 rounded-full border border-red-700 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-red-500 dark:text-red-500 dark:bg-transparent">
                     Error
                 </button>
             );

--- a/client/src/app/features/components/OnOffButton.tsx
+++ b/client/src/app/features/components/OnOffButton.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 
 interface ButtonProps {
     onClick: () => void;
-    isConnected: boolean;
+    currentStatus: number;
 }
 
-const OnOffButton: React.FC<ButtonProps> = ({ onClick, isConnected }) => (
+const OnOffButton: React.FC<ButtonProps> = ({ onClick, currentStatus }) => (
     <button
-        onClick={onClick}
+        onClick={onClick} // コールバックを直接渡す
         className="py-2.5 px-5 me-2 text-sm font-medium text-gray-900 rounded-full bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:outline-none focus:ring-blue-700 focus:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 inline-flex items-center"
     >
-        {isConnected ? "切断する" : "接続する"}
+        {/* 会議の開始 -> websocket上でのstatusをtrueにしてsmilePoint等を受付状態にする */}
+        {currentStatus === 1 ? "会議を終了する" : "会議を開始する"}
     </button>
 );
 


### PR DESCRIPTION
## 本PRでやったこと
- websocket自体は常にONなので、会議のstatusをserver側で持つようにし、statusがOFFのときはsmilePointなどを受け取らない（受け取っているがserver側でupdateされない）ように変更