### PR TITLE
[front/fix] 接続中のClientsが表示されないバグの修正

### DIFF
--- a/client/src/app/features/Chat.tsx
+++ b/client/src/app/features/Chat.tsx
@@ -89,10 +89,12 @@ const Chat: React.FC = () => {
         }
     }, []);
 
-    // デフォルトでwebSocketに接続
+    // nicknameがセットされたのち、webSocketにデフォルトで接続
     useEffect(() => {
-        startConnectWebSocket(socketRef, nickname, setMessages, setTotalSmilePoint, setTotalIdeas, setCurrentImage, setLevel, setClientsList, setStatus);
-    }, []);
+        if (nickname) {
+            startConnectWebSocket(socketRef, nickname, setMessages, setTotalSmilePoint, setTotalIdeas, setCurrentImage, setLevel, setClientsList, setStatus);
+        }
+    }, [nickname]);
 
     // smilePointが変化したら発火
     useEffect(() => {


### PR DESCRIPTION
## 本PRでやったこと
- Chat.tsxでwebsocket通信を開始する時に、nicknameを取得する前に接続を始めていることで非表示になっていたため、nicknameに依存するように変更した。