### PR TITLE
[front-back/feat] ストップウォッチ機能の実装

### DIFF
--- a/client/src/app/features/Chat.tsx
+++ b/client/src/app/features/Chat.tsx
@@ -42,6 +42,7 @@ const Chat: React.FC = () => {
     const [hearts, setHearts] = useState<{ id: string }[]>([]);
     const [foods, setFoods] = useState<{ id: string, foodsIndex: number }[]>([]);
     const [isMeetingActive, setIsMeetingActive] = useState(false); // Serverサイドの会議開始/終了の制御
+    const [timer, setTimer] = useState("00:00:00");
 
     const { smileProb, userExpressions, stream } = useSmileDetection(videoRef);
 
@@ -92,7 +93,7 @@ const Chat: React.FC = () => {
     // nicknameがセットされたのち、webSocketにデフォルトで接続
     useEffect(() => {
         if (nickname) {
-            startConnectWebSocket(socketRef, nickname, setMessages, setTotalSmilePoint, setTotalIdeas, setCurrentImage, setLevel, setClientsList, setStatus);
+            startConnectWebSocket(socketRef, nickname, setTimer, setMessages, setTotalSmilePoint, setTotalIdeas, setCurrentImage, setLevel, setClientsList, setStatus);
         }
     }, [nickname]);
 
@@ -224,6 +225,7 @@ const Chat: React.FC = () => {
                                     {nickname === process.env.NEXT_PUBLIC_ADMIN_NICKNAME && (
                                         <OnOffButton onClick={handleOnOffButtonClick} currentStatus={status} />
                                     )}
+                                    <div>経過時間: {timer}</div>
                                     <IdeasButton onClick={() => sendIdea(socketRef, clientId, nickname, setStatus)} totalIdeas={totalIdeas} disabled={status !== 1} />
                                 </div>
 
@@ -250,6 +252,7 @@ const Chat: React.FC = () => {
                                 {nickname === process.env.NEXT_PUBLIC_ADMIN_NICKNAME && (
                                     <OnOffButton onClick={handleOnOffButtonClick} currentStatus={status} />
                                 )}
+                                <div>経過時間: {timer}</div>
                                 <div>
                                     <IdeasButton onClick={() => sendIdea(socketRef, clientId, nickname, setStatus)} totalIdeas={totalIdeas} disabled={status !== 1} />
                                 </div>

--- a/client/src/app/features/Chat.tsx
+++ b/client/src/app/features/Chat.tsx
@@ -225,7 +225,7 @@ const Chat: React.FC = () => {
                                     {nickname === process.env.NEXT_PUBLIC_ADMIN_NICKNAME && (
                                         <OnOffButton onClick={handleOnOffButtonClick} currentStatus={status} />
                                     )}
-                                    <div>経過時間: {timer}</div>
+                                    <div>経過: {timer}</div>
                                     <IdeasButton onClick={() => sendIdea(socketRef, clientId, nickname, setStatus)} totalIdeas={totalIdeas} disabled={status !== 1} />
                                 </div>
 
@@ -252,7 +252,7 @@ const Chat: React.FC = () => {
                                 {nickname === process.env.NEXT_PUBLIC_ADMIN_NICKNAME && (
                                     <OnOffButton onClick={handleOnOffButtonClick} currentStatus={status} />
                                 )}
-                                <div>経過時間: {timer}</div>
+                                <div>経過: {timer}</div>
                                 <div>
                                     <IdeasButton onClick={() => sendIdea(socketRef, clientId, nickname, setStatus)} totalIdeas={totalIdeas} disabled={status !== 1} />
                                 </div>

--- a/client/src/app/features/Chat.tsx
+++ b/client/src/app/features/Chat.tsx
@@ -21,6 +21,7 @@ import ResizeButton from "./components/ResizeButton";
 import BorderEffect from "./components/BorderEffect";
 import Heart from "./components/Heart";
 import Food from "./components/Food";
+import TimerDisplay from "./components/TimerDisplay";
 
 const Chat: React.FC = () => {
     const router = useRouter();
@@ -225,7 +226,7 @@ const Chat: React.FC = () => {
                                     {nickname === process.env.NEXT_PUBLIC_ADMIN_NICKNAME && (
                                         <OnOffButton onClick={handleOnOffButtonClick} currentStatus={status} />
                                     )}
-                                    <div>経過: {timer}</div>
+                                    <TimerDisplay timer={timer} />
                                     <IdeasButton onClick={() => sendIdea(socketRef, clientId, nickname, setStatus)} totalIdeas={totalIdeas} disabled={status !== 1} />
                                 </div>
 
@@ -252,7 +253,7 @@ const Chat: React.FC = () => {
                                 {nickname === process.env.NEXT_PUBLIC_ADMIN_NICKNAME && (
                                     <OnOffButton onClick={handleOnOffButtonClick} currentStatus={status} />
                                 )}
-                                <div>経過: {timer}</div>
+                                <TimerDisplay timer={timer} />
                                 <div>
                                     <IdeasButton onClick={() => sendIdea(socketRef, clientId, nickname, setStatus)} totalIdeas={totalIdeas} disabled={status !== 1} />
                                 </div>

--- a/client/src/app/features/Login.tsx
+++ b/client/src/app/features/Login.tsx
@@ -29,12 +29,7 @@ const Login: React.FC = () => {
             });
             if (response.ok) {
                 sessionStorage.setItem("login_password", password); // tokenをsession storageに格納
-                if (nickname === process.env.NEXT_PUBLIC_ADMIN_NICKNAME) {
-                    // ADMIN_NICKNAMEを隠すため、nicknameを"管理者"に上書き
-                    localStorage.setItem("nickname", "管理者");
-                } else {
-                    localStorage.setItem("nickname", nickname);
-                }
+                localStorage.setItem("nickname", nickname);
                 setError(null);
                 setIsLoading(true); // ローディング開始
                 router.push("/chat");

--- a/client/src/app/features/components/TimerDisplay.tsx
+++ b/client/src/app/features/components/TimerDisplay.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface TimerDisplayProps {
+    timer: string;
+}
+
+const TimerDisplay: React.FC<TimerDisplayProps> = ({ timer }) => {
+    return (
+        <div className="p-4 bg-gray-100 border border-gray-300 rounded-lg shadow-md flex items-center justify-center text-lg font-semibold text-gray-700 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200">
+            <svg
+                className="w-6 h-6 mr-2 text-purple-600 dark:text-purple-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-7a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span className="leading-none">{timer}</span>
+        </div>
+    );
+};
+
+export default TimerDisplay;

--- a/client/src/app/features/hooks/useWebSocket.ts
+++ b/client/src/app/features/hooks/useWebSocket.ts
@@ -4,6 +4,7 @@ import ReconnectingWebSocket from 'reconnecting-websocket';
 export const startConnectWebSocket = (
     socketRef: React.MutableRefObject<ReconnectingWebSocket | null>,
     nickname: string,
+    setTimer: Dispatch<SetStateAction<string>>,
     setMessages: Dispatch<SetStateAction<string[]>>,
     setTotalSmilePoint: Dispatch<SetStateAction<number>>,
     setTotalIdeas: Dispatch<SetStateAction<number>>,
@@ -51,6 +52,8 @@ export const startConnectWebSocket = (
                 setCurrentImage(data.imageUrl);
             } else if (data.type === "level") {
                 setLevel(data.level);
+            } else if (data.type === "timer") {
+                setTimer(data.timer);
             } else if (data.type == "meetingStatus") {
                 if (data.isMeetingActive === true) {
                     console.log("Meeting is now active");

--- a/server/src/firebase/firebase.go
+++ b/server/src/firebase/firebase.go
@@ -51,29 +51,33 @@ func CloseFirestore() {
 }
 
 type SmilePoint struct {
-	Timestamp       time.Time `firestore:"timestamp"`
-	ClientId        string    `firestore:"client_id"`
-	Nickname        string    `firestore:"nickname"`
-	Point           int       `firestore:"smile_point"`
-	TotalSmilePoint int       `firestore:"total_smile_point"`
+	Timestamp         time.Time `firestore:"timestamp"`
+	SinceMeetingStart int64     `firestore:"since_meeting_start"`
+	ClientId          string    `firestore:"client_id"`
+	Nickname          string    `firestore:"nickname"`
+	Point             int       `firestore:"smile_point"`
+	TotalSmilePoint   int       `firestore:"total_smile_point"`
 }
 
 type SmileIdea struct {
-	Timestamp time.Time `firestore:"timestamp"`
-	ClientId  string    `firestore:"client_id"`
-	Nickname  string    `firestore:"nickname"`
+	Timestamp         time.Time `firestore:"timestamp"`
+	SinceMeetingStart int64     `firestore:"since_meeting_start"`
+	ClientId          string    `firestore:"client_id"`
+	Nickname          string    `firestore:"nickname"`
 }
 
 type SmileImage struct {
-	Timestamp       time.Time `firestore:"timestamp"`
-	TotalSmilePoint int       `firestore:"total_smile_point"`
-	Prompt          string    `firestore:"prompt"`
-	ImageUrl        string    `firestore:"image_url"`
+	Timestamp         time.Time `firestore:"timestamp"`
+	SinceMeetingStart int64     `firestore:"since_meeting_start"`
+	TotalSmilePoint   int       `firestore:"total_smile_point"`
+	Prompt            string    `firestore:"prompt"`
+	ImageUrl          string    `firestore:"image_url"`
 }
 
 type SmileLevel struct {
-	Timestamp time.Time `firestore:"timestamp"`
-	Level     int       `firestore:"level"`
+	Timestamp         time.Time `firestore:"timestamp"`
+	SinceMeetingStart int64     `firestore:"since_meeting_start"`
+	Level             int       `firestore:"level"`
 }
 
 func SaveSmilePoint(sp SmilePoint) error {

--- a/server/src/websocket/websocket.go
+++ b/server/src/websocket/websocket.go
@@ -89,8 +89,8 @@ func (s *Server) handleMeetingStatus(message Message) {
 		// 経過時間を毎秒送信
 		go func() {
 			for s.isMeetingActive {
-				elapsedTime := time.Since(s.meetingStartTime).Seconds()
-				s.timerBroadcast <- int64(elapsedTime)
+				elapsedTime := int64(time.Since(s.meetingStartTime).Seconds())
+				s.timerBroadcast <- elapsedTime
 				time.Sleep(1 * time.Second)
 			}
 		}()
@@ -237,11 +237,12 @@ func (s *Server) handleMessage(message Message) {
 
 func (s *Server) handleSmilePoint(message Message) {
 	firestoreSmilePointField := firebase.SmilePoint{
-		Timestamp:       message.Timestamp,
-		ClientId:        message.ClientId,
-		Nickname:        message.Nickname,
-		Point:           message.Point,
-		TotalSmilePoint: s.totalSmilePoint,
+		Timestamp:         message.Timestamp,
+		SinceMeetingStart: int64(time.Since(s.meetingStartTime).Seconds()),
+		ClientId:          message.ClientId,
+		Nickname:          message.Nickname,
+		Point:             message.Point,
+		TotalSmilePoint:   s.totalSmilePoint,
 	}
 	if err := firebase.SaveSmilePoint(firestoreSmilePointField); err != nil {
 		log.Println("Error inserting smile_point into Firestore: ", err)
@@ -271,8 +272,9 @@ func (s *Server) handleSmilePoint(message Message) {
 	// レベルが変化していたらFirestoreにLevelを保存
 	if previousLevel != s.level {
 		firestoreSmileLevelField := firebase.SmileLevel{
-			Timestamp: message.Timestamp,
-			Level:     s.level,
+			Timestamp:         message.Timestamp,
+			SinceMeetingStart: int64(time.Since(s.meetingStartTime).Seconds()),
+			Level:             s.level,
 		}
 		if err := firebase.SaveSmileLevel(firestoreSmileLevelField); err != nil {
 			log.Println("Error inserting smile_level into Firestore: ", err)
@@ -284,10 +286,11 @@ func (s *Server) handleSmilePoint(message Message) {
 		imageUrl, err := generateImageUrl()
 		if err == nil && imageUrl != "" {
 			firestoreSmileImageField := firebase.SmileImage{
-				Timestamp:       message.Timestamp,
-				TotalSmilePoint: s.totalSmilePoint,
-				Prompt:          "A dog, high resolution, golden retriever, peaceful, smile, not sick, happy",
-				ImageUrl:        imageUrl,
+				Timestamp:         message.Timestamp,
+				SinceMeetingStart: int64(time.Since(s.meetingStartTime).Seconds()),
+				TotalSmilePoint:   s.totalSmilePoint,
+				Prompt:            "A dog, high resolution, golden retriever, peaceful, smile, not sick, happy",
+				ImageUrl:          imageUrl,
 			}
 			if err := firebase.SaveSmileImage(firestoreSmileImageField); err != nil {
 				log.Println("Error inserting smile_image into Firestore: ", err)
@@ -303,9 +306,10 @@ func (s *Server) handleSmilePoint(message Message) {
 
 func (s *Server) handleIdea(message Message) {
 	firestoreIdeaField := firebase.SmileIdea{
-		Timestamp: message.Timestamp,
-		ClientId:  message.ClientId,
-		Nickname:  message.Nickname,
+		Timestamp:         message.Timestamp,
+		SinceMeetingStart: int64(time.Since(s.meetingStartTime).Seconds()),
+		ClientId:          message.ClientId,
+		Nickname:          message.Nickname,
 	}
 	if err := firebase.SaveSmileIdea(firestoreIdeaField); err != nil {
 		log.Println("Error inserting idea into Firestore: ", err)


### PR DESCRIPTION
## 本PRでやったこと
- バックエンド側に経過時間を管理するmeetingStartTimeを追加し、毎秒フロント側に渡す
- firebaseで保存する時、この経過時間[s]もsince_meeting_startとして追加 -> 分析をより円滑にする